### PR TITLE
Compatibility updates and online documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: continuous-integration
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version: [1.5, 1]
+        arch: [x64]
+        os: [ubuntu-18.04] # macos-10.15, windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Julia Setup
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Build
+        uses: julia-actions/julia-buildpkg@v1
+      - name: Test
+        uses: julia-actions/julia-runtest@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coverage Process
+        uses: julia-actions/julia-processcoverage@v1
+        if:  ${{ startsWith(matrix.os, 'ubuntu') && (matrix.version == '1') }}
+      - name: Coverage Upload
+        uses: codecov/codecov-action@v1
+        if:  ${{ startsWith(matrix.os, 'ubuntu') && (matrix.version == '1') }}
+        with:
+          file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,14 @@ on:
   push:
     branches:
       - master
+      - main
     paths-ignore:
       - 'LICENSE.md'
       - 'README.md'
   pull_request:
     branches:
       - master
+      - main
     paths-ignore:
       - 'LICENSE.md'
       - 'README.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'LICENSE.md'
       - 'README.md'
+      - 'examples/**'
   pull_request:
     branches:
       - master
@@ -14,6 +15,7 @@ on:
     paths-ignore:
       - 'LICENSE.md'
       - 'README.md'
+      - 'examples/**'
 jobs:
   ci:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -18,6 +18,5 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:
-        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -1,11 +1,14 @@
 name: Documenter
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - main
     tags: [v*]
   pull_request:
     branches:
       - master
+      - main
 jobs:
   Documenter:
     name: Documentation

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -1,0 +1,20 @@
+name: Documenter
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+    branches:
+      - master
+jobs:
+  Documenter:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 
 [compat]
 AbstractPlotting = "0.18"
-DataFrames = "1.1"
-MixedModels = "3.6,4"
+DataFrames = "1"
+MixedModels = "3.6, 4"
 julia = "1.5"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # MixedModelsMakie
+
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![Stable Docs][docs-stable-img]][docs-stable-url]
+[![Dev Docs][docs-dev-img]][docs-dev-url]
+[![Codecov](https://codecov.io/gh/palday/MixedModelsMakie.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/palday/MixedModelsMakie.jl)
+
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://palday.github.io/MixedModelsMakie.jl/dev
+
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
+[docs-stable-url]: https://palday.github.io/MixedModelsMakie.jl/stable
+
+`MixedModelsMakie.jl` is a Julia package providing plotting capabilities for models fit with [MixedModels.jl](https://juliastats.org/MixedModels.jl/stable/).
+Plotting is performed using the [Makie ecoysystem](https://makie.juliaplots.org/stable/), with the interface defined using `AbstractPlotting.jl` for compatibility across all Makie backends.
+
+Note that the functionality here is currently early alpha development and so breaking changes are expected as we refine the interface.
+Following [SemVer](https://semver.org/), these minor releases before 1.0 can introduce these breaking changes.
+The release of 1.0 will be indication that we believe the interface is reasonably stable.
+Minor refinements of graphical displays without changing the API are considered non-breaking.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MixedModelsExtras = "781a26e1-49f4-409a-8f4c-c3159d78c17e"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,3 +3,7 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 MixedModelsMakie = "b12ae82c-6730-437f-aff9-d2c38332a376"
+
+[compat]
+CairoMakie = "0.4.7"
+Documenter = "0.26"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-MixedModelsExtras = "781a26e1-49f4-409a-8f4c-c3159d78c17e"
+MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
+MixedModelsMakie = "b12ae82c-6730-437f-aff9-d2c38332a376"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,15 @@
+using Documenter
+using MixedModelsMakie
+
+makedocs(;
+    root = joinpath(dirname(pathof(MixedModelsMakie)), "..", "docs"),
+    sitename = "MixedModelsMakie",
+    doctest = true,
+    checkdocs = :exports,
+    pages = [
+        "index.md",
+        "api.md",
+    ],
+)
+
+deploydocs(repo = "github.com/palday/MixedModelsMakie.jl.git", push_preview = true)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,7 +26,7 @@ caterpillar
 caterpillar!
 ```
 
-```@example
+```@example Caterpillar
 using CairoMakie
 CairoMakie.activate!(type = "svg")
 using MixedModels
@@ -37,6 +37,9 @@ fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstud
 subjre = ranefinfo(fm1)[:subj]
 
 caterpillar!(Figure(; resolution=(800,600)), subjre)
+```
+
+```@example Caterpillar
 caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=2)
 ```
 
@@ -58,7 +61,7 @@ shrinkageplot
 shrinkageplot!
 ```
 
-```@example
+```@example Shrinkage
 using CairoMakie
 using MixedModels
 using MixedModelsMakie

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,10 +58,6 @@ shrinkageplot
 shrinkageplot!
 ```
 
-```@docs
-shrinkage2d!
-```
-
 ```@example
 using CairoMakie
 using MixedModels

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,13 +28,16 @@ caterpillar!
 
 ```@example
 using CairoMakie
+CairoMakie.activate!(type = "svg")
 using MixedModels
 using MixedModelsMakie
 sleepstudy = MixedModels.dataset(:sleepstudy)
 
 fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstudy)
+subjre = ranefinfo(fm1)[:subj]
 
-caterpillar(fm1)
+caterpillar!(Figure(; resolution=(800,600)), subjre)
+caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=2)
 ```
 
 ## Shrinkage Plots
@@ -66,6 +69,7 @@ using MixedModelsMakie
 sleepstudy = MixedModels.dataset(:sleepstudy)
 
 fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstudy)
+shrink = shrinkage(fm1)[:subj]
 
-shrinkageplot(fm1)
+shrinkageplot!(Figure(; resolution=(800,600)), shrink)
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,71 @@
+```@meta
+CurrentModule = MixedModelsMakie
+DocTestSetup = quote
+    using MixedModelsMakie
+end
+DocTestFilters = [r"([a-z]*) => \1", r"getfield\(.*##[0-9]+#[0-9]+"]
+```
+
+# MixedModelsMakie.jl API
+
+## Caterpillar Plots
+
+```@docs
+RanefInfo
+```
+
+```@docs
+ranefinfo
+```
+
+```@docs
+caterpillar
+```
+
+```@docs
+caterpillar!
+```
+
+```@example
+using CairoMakie
+using MixedModels
+using MixedModelsMakie
+sleepstudy = MixedModels.dataset(:sleepstudy)
+
+fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstudy)
+
+caterpillar(fm1)
+```
+
+## Shrinkage Plots
+
+```@docs
+CoefByGroup
+```
+
+```@docs
+shrinkage
+```
+
+```@docs
+shrinkageplot
+```
+
+```@docs
+shrinkageplot!
+```
+
+```@docs
+shrinkage2d!
+```
+
+```@example
+using CairoMakie
+using MixedModels
+using MixedModelsMakie
+sleepstudy = MixedModels.dataset(:sleepstudy)
+
+fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstudy)
+
+shrinkageplot(fm1)
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,10 @@ CurrentModule = MixedModelsMakie
 
 *MixedModelsMakie.jl* is a Julia package providing plotting capabilities for models fit with [MixedModels.jl](https://juliastats.org/MixedModels.jl/stable/).
 
+Note that the functionality here is currently early alpha development and so breaking changes are expected as we refine the interface.
+Following [SemVer](https://semver.org/), these minor releases before 1.0 can introduce these breaking changes.
+The release of 1.0 will be indication that we believe the interface is reasonably stable.
+
 ```@contents
 Pages = [
         "api.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,14 @@
+# MixedModelsMakie.jl Documentation
+
+```@meta
+CurrentModule = MixedModelsMakie
+```
+
+*MixedModelsMakie.jl* is a Julia package providing plotting capabilities for models fit with [MixedModels.jl](https://juliastats.org/MixedModels.jl/stable/).
+
+```@contents
+Pages = [
+        "api.md",
+]
+Depth = 1
+```

--- a/src/MixedModelsMakie.jl
+++ b/src/MixedModelsMakie.jl
@@ -13,6 +13,7 @@ module MixedModelsMakie
         ranefinfo,
         shrinkage,
         shrinkageplot,
+        shrinkageplot!,
         simplelinreg
 
     include("shrinkage.jl")

--- a/src/caterpillar.jl
+++ b/src/caterpillar.jl
@@ -3,7 +3,10 @@
 
 Information on random effects conditional modes/means, variances, etc.
 
-Used for creating caterpillar plots
+Used for creating caterpillar plots.
+
+!!! note
+    This functionality may be moved upstream into MixedModels.jl in the near future.
 """
 struct RanefInfo{T<:AbstractFloat}
     cnames::Vector{String}
@@ -48,18 +51,17 @@ function caterpillar!(f::Figure, r::RanefInfo; orderby=1)
     ord = sortperm(vv)
     y = axes(rr, 1)
     cn = r.cnames
-
-    @show axs = [Axis(f[1, j]) for j in axes(rr, 2)]
-    #linkyaxes!(axs...)
-    # for (j, ax) in enumerate(axs)
-    #     xvals = view(rr, ord, j)
-    #     #scatter!(ax, xvals, y, color=(:red, 0.2))
-    #     #errorbars!(ax, xvals, y, view(r.stddev, ord, j), direction=:x)
-    #     ax.xlabel = cn[j]
-    #     ax.yticks = y
-    #     j > 1 && hideydecorations!(ax, grid=false)
-    # end
-    # axs[1].yticks = (y, r.levels[ord])
+    axs = [Axis(f[1, j]) for j in axes(rr, 2)]
+    linkyaxes!(axs...)
+    for (j, ax) in enumerate(axs)
+        xvals = view(rr, ord, j)
+        scatter!(ax, xvals, y, color=(:red, 0.2))
+        errorbars!(ax, xvals, y, view(r.stddev, ord, j), direction=:x)
+        ax.xlabel = cn[j]
+        ax.yticks = y
+        j > 1 && hideydecorations!(ax, grid=false)
+    end
+    axs[1].yticks = (y, r.levels[ord])
     f
 end
 

--- a/src/caterpillar.jl
+++ b/src/caterpillar.jl
@@ -22,7 +22,7 @@ function ranefinfo(m::LinearMixedModel{T}) where {T}
     val = sizehint!(RanefInfo[], length(fn))
     for (re, eff, cv) in zip(m.reterms, ranef(m), condVar(m))
         push!(
-            val, 
+            val,
             RanefInfo(
                 re.cnames,
                 re.levels,
@@ -48,17 +48,18 @@ function caterpillar!(f::Figure, r::RanefInfo; orderby=1)
     ord = sortperm(vv)
     y = axes(rr, 1)
     cn = r.cnames
-    axs = [Axis(f[1, j]) for j in axes(rr, 2)]
-    linkyaxes!(axs...)
-    for (j, ax) in enumerate(axs)
-        xvals = view(rr, ord, j)
-        scatter!(ax, xvals, y, color=(:red, 0.2))
-        errorbars!(ax, xvals, y, view(r.stddev, ord, j), direction=:x)
-        ax.xlabel = cn[j]
-        ax.yticks = y
-        j > 1 && hideydecorations!(ax, grid=false)
-    end
-    axs[1].yticks = (y, r.levels[ord])
+
+    @show axs = [Axis(f[1, j]) for j in axes(rr, 2)]
+    #linkyaxes!(axs...)
+    # for (j, ax) in enumerate(axs)
+    #     xvals = view(rr, ord, j)
+    #     #scatter!(ax, xvals, y, color=(:red, 0.2))
+    #     #errorbars!(ax, xvals, y, view(r.stddev, ord, j), direction=:x)
+    #     ax.xlabel = cn[j]
+    #     ax.yticks = y
+    #     j > 1 && hideydecorations!(ax, grid=false)
+    # end
+    # axs[1].yticks = (y, r.levels[ord])
     f
 end
 

--- a/src/shrinkage.jl
+++ b/src/shrinkage.jl
@@ -9,6 +9,9 @@ Fields include:
 - `fixed`: `AbstractVector{T}` of the global OLS estimates for the coefficients in `cnames` only.
 - `condmodes`: `AbstractMatrix{T}` of size `length(levels) x length(cnames)` of the conditional means/modes for the random effects
 - `grpest`: similar to `condmodes` but allowing for `Missing` values, giving the within group OLS estimates of the coefficients.
+
+!!! note
+    This functionality may be moved upstream into MixedModels.jl in the near future.
 """
 struct CoefByGroup{T<:AbstractFloat}
     cnames::Vector{String}

--- a/src/shrinkage.jl
+++ b/src/shrinkage.jl
@@ -24,14 +24,18 @@ end
 Return a `NamedTuple{fnames(m), NTuple(k, CoefByGroup)}` of the coefficients by group for the grouping factors
 """
 function shrinkage(m::LinearMixedModel{T}) where {T}
-    fenms = m.feterm.cnames
-    yvec = view(m.Xymat, :, size(m.Xymat, 2))
+    # should this be fixefnames or coefnames?
+    # need to think about when pivoting is occuring
+    fenms = fixefnames(m)
+    # returns a view from Xymat in MM4, or just the response vec in MM3.x
+    yvec = response(m)
     ranefs = ranef(m)
     cvec = sizehint!(CoefByGroup[], length(ranefs))
     for (j, re) in enumerate(m.reterms)
         cnms = re.cnames
         cnms ⊆ fenms || throw(ArgumentError("No corresponding fixed effect for random effects $(setdiff(cnms, fenms)): there is no estimated grand mean to measure shrinkage towards"))
-        Xmat = view(m.Xymat, :, [findfirst(==(nm), fenms) for nm in cnms])
+        # XXX Should m.X return a view into m.Xymat?
+        Xmat = view(m.X, :, [findfirst(==(nm), fenms) for nm in cnms])
         levs = re.levels
         refs = re.refs
         grpest = Matrix{Union{Missing,T}}(missing, (length(levs), length(cnms)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using MixedModelsMakie
 using Test
 
-@testset "MixedModelsMakie.jl" begin
-    # Write your tests here.
+@testset "There are no tests" begin
+    @test true
 end


### PR DESCRIPTION
@dmbates I had to make the construction of the fixed-effects model matrix slightly less efficient for MixedModels 3.0 compatibility. That highlighted to me that we should probably make `LinearMixedModel.X` return a view into `Xymat` in 4.0.