### PR TITLE
Don't use small integers to accumulate large sums.

### DIFF
--- a/src/xyplot.jl
+++ b/src/xyplot.jl
@@ -41,6 +41,7 @@ end
 Return the coefficients, `[a, b]`,  from a simple linear regression, `y = a + bx + ϵ`
 """
 function simplelinreg(x, y)
+    x, y = float(x), float(y)
     A = cholesky!(Symmetric([length(x) sum(x) sum(y); 0.0 sum(abs2, x) dot(x, y); 0.0 0.0 sum(abs2, y)])).factors
     ldiv!(UpperTriangular(view(A, 1:2, 1:2)), view(A, 1:2, 3))
 end


### PR DESCRIPTION
It took a while to discover why `simplelinreg` was failing on cases where I didn't think it should.  Turns out that `sum(abs2, Int8[8,10,12,14])` is `-8`. 