### PR TITLE
Return a Tuple from simplelinreg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModelsMakie"
 uuid = "b12ae82c-6730-437f-aff9-d2c38332a376"
 authors = ["Phillip Alday <me@phillipalday.com>, Douglas Bates <dmbates@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/xyplot.jl
+++ b/src/xyplot.jl
@@ -38,10 +38,10 @@ end
 """
     simplelinreg(x, y)
 
-Return the coefficients, `[a, b]`,  from a simple linear regression, `y = a + bx + ϵ`
+Return a Tuple of the coefficients, `(a, b)`,  from a simple linear regression, `y = a + bx + ϵ`
 """
 function simplelinreg(x, y)
     x, y = float(x), float(y)
     A = cholesky!(Symmetric([length(x) sum(x) sum(y); 0.0 sum(abs2, x) dot(x, y); 0.0 0.0 sum(abs2, y)])).factors
-    ldiv!(UpperTriangular(view(A, 1:2, 1:2)), view(A, 1:2, 3))
+    (ldiv!(UpperTriangular(view(A, 1:2, 1:2)), view(A, 1:2, 3))..., )
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,18 @@
 using MixedModelsMakie
+using Random # we don't depend on exact PRNG vals, so no need for StableRNGs
 using Test
 
-@testset "There are no tests" begin
+@testset "There are no graphical tests" begin
     @test true
+end
+
+@testset "Simple linear regression" begin
+    a, b = 1, 2
+    x = collect(1:10)
+    y = randn(MersenneTwister(42), 10) * 0.1
+    @. y += a + b * x
+    result = simplelinreg(x, y)
+    @test result isa Tuple
+    @test a ≈ result[1] atol=0.05
+    @test b ≈ result[2] atol=0.05
 end


### PR DESCRIPTION
```julia
combine(groupby(...), [:x, :y] => simplelinreg => :coef)
```
works better when `simplelinreg` returns a `Tuple`.

- longer term we may want to consider a mechanism to return the coefficient estimates, `s` and `R` from the model.  This will allow the simple mechanism to be used to create the confidence band.
- for reference, R, the upper triangular part of R from the QR decomposition (also the upper Cholesky factor of X'X) is `UpperTriangular(view(A, 1:2, 1:2))`, the matrix in the call to `ldiv!`.  `A[3, 3]` is the square root of the sum of squared residuals.