### PR TITLE
Change to column table from shrinkage

### DIFF
--- a/src/MixedModelsMakie.jl
+++ b/src/MixedModelsMakie.jl
@@ -1,4 +1,5 @@
 module MixedModelsMakie
+    using DataFrames
     using LinearAlgebra
     using Makie
     using MixedModels

--- a/src/xyplot.jl
+++ b/src/xyplot.jl
@@ -35,6 +35,14 @@ function clevelandaxes!(f::Figure, labs, layout)
     f
 end
 
+function clevelandaxes!(f::Figure, labs::GroupedDataFrame, layout)
+    kvals = keys(labs)
+    if !isone(length(first(kvals)))
+        throw(ArgumentError("labs as a GroupedDataFrame should have only one grouping factor"))
+    end
+    clevelandaxes!(f, first.(kvals), layout)
+end
+
 """
     simplelinreg(x, y)
 


### PR DESCRIPTION
There is a lot of effort in `shrinkage` to deal with cases where the within-group coefficients can't be calculated, e.g. if there are fewer observations on a group than the dimension of the random effects.  This happens in longitudinal data where some subjects just entered the study and have only one observation but there is a random effect for the slope with respect to time by subject.

Turns out that the polyalgorithm for `X \ y` handles this case, presumably using the Moore-Penrose inverse of `X`.

I went further and changed the `CoefByGroup` struct to two `NamedTuples`.  The first field, `globalest`, is global coefficient estimates as a `NamedTuple` (to incorporate the coefficient names).  The second field, `withinmxdtbl`, is a column table with columns `level`, `mixed` and `within`.  The last two are vectors of `NTuple{N,T}` where `N` is the number of coefficients.

These produce some interesting plots for "maximal" models with crossed grouping factors (e.g. subject/item).  When the variances of the random effects are small the shrinkage is dramatic.