### PR TITLE
Switch to shrinkageplot from θref

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModelsMakie"
 uuid = "b12ae82c-6730-437f-aff9-d2c38332a376"
 authors = ["Phillip Alday <me@phillipalday.com>, Douglas Bates <dmbates@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ MixedModelsMakie = "b12ae82c-6730-437f-aff9-d2c38332a376"
 
 [compat]
 CairoMakie = "0.5"
-Documenter = "0.26"
+Documenter = "0.27"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,7 +28,7 @@ caterpillar!
 
 ```@example Caterpillar
 using CairoMakie
-CairoMakie.activate!(type = "png")
+CairoMakie.activate!(type = "svg")
 using MixedModels
 using MixedModelsMakie
 sleepstudy = MixedModels.dataset(:sleepstudy)
@@ -50,20 +50,9 @@ caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=nothing)
 ## Shrinkage Plots
 
 ```@docs
-CoefByGroup
-```
-
-```@docs
-shrinkage
-```
-
-```@docs
 shrinkageplot
 ```
 
-```@docs
-shrinkageplot!
-```
 
 ```@example Shrinkage
 using CairoMakie
@@ -72,7 +61,5 @@ using MixedModelsMakie
 sleepstudy = MixedModels.dataset(:sleepstudy)
 
 fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstudy)
-shrink = shrinkage(fm1)[:subj]
-
-shrinkageplot!(Figure(; resolution=(800,600)), shrink)
+shrinkageplot(fm1)
 ```

--- a/src/MixedModelsMakie.jl
+++ b/src/MixedModelsMakie.jl
@@ -4,16 +4,13 @@ module MixedModelsMakie
     using MixedModels
 
     export
-        CoefByGroup,
         RanefInfo,
 
         caterpillar,
         caterpillar!,
         clevelandaxes!,
         ranefinfo,
-        shrinkage,
         shrinkageplot,
-        shrinkageplot!,
         simplelinreg
 
     include("shrinkage.jl")

--- a/src/shrinkage.jl
+++ b/src/shrinkage.jl
@@ -22,9 +22,14 @@ function shrinkageplot(
     cnms = m.reterms[reind].cnames
     f = Figure(; resolution=(1000, 1000)) # use an aspect ratio of 1 for the whole figure
     k = size(reest, 1)  # dimension of the random-effects vector per level of gf
+	cols = Dict()
     for i in 2:k                          # strict lower triangle of panels
+		row = Axis[]
         for j in 1:(i - 1)
             ax = Axis(f[i - 1, j])
+			push!(row, ax)
+			col = get!(cols, j, Axis[])
+			push!(col, ax)
             x, y = view(reref, j, :), view(reref, i, :)
             scatter!(ax, x, y; color=(:red, 0.25))   # reference points
             u, v = view(reest, j, :), view(reest, i, :)
@@ -37,10 +42,16 @@ function shrinkageplot(
             end
             if isone(j)            # add y labels on left column
                 ax.ylabel = string(cnms[i])
-            else 
+            else
                 hideydecorations!(ax; grid=false)
             end
         end
+		linkyaxes!(row...)
     end
+
+	foreach(values(cols)) do col
+		linkxaxes!(col...)
+	end
+
     return f
 end


### PR DESCRIPTION
As discussed in email, this version of `shrinkageplot` compares the BLUPs at the estimates with those at `θref`.  The default `θref` creates a `Λ = 10000 * I` so that `Λ'Z'ZΛ + I` is essentially `Λ'Z'ZΛ` with just enough regularization so that BLUPs can be evaluated.  These BLUPs can be considered as the values of `b` before shrinkage.