### PR TITLE
Scale residuals so that `qqplot` is against standard normal

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -2,7 +2,7 @@
 
 # XXX it would be great to have a 1-1 aspect ratio here,
 # but this seems like something that should be done upstream
-Makie.convert_arguments(P::Type{<:Makie.QQNorm}, x::MixedModel) = convert_arguments(P, residuals(x) ./ x.σ)
+Makie.convert_arguments(P::Type{<:Makie.QQNorm}, x::MixedModel) = convert_arguments(P, residuals(x) ./ dispersion(x))
 Makie.convert_arguments(P::Type{<:Makie.QQPlot}, d::Distributions.Distribution, x::MixedModel) = convert_arguments(P, d, residuals(x))
 
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -2,7 +2,7 @@
 
 # XXX it would be great to have a 1-1 aspect ratio here,
 # but this seems like something that should be done upstream
-Makie.convert_arguments(P::Type{<:Makie.QQNorm}, x::MixedModel) = convert_arguments(P, residuals(x))
+Makie.convert_arguments(P::Type{<:Makie.QQNorm}, x::MixedModel) = convert_arguments(P, residuals(x) ./ x.σ)
 Makie.convert_arguments(P::Type{<:Makie.QQPlot}, d::Distributions.Distribution, x::MixedModel) = convert_arguments(P, d, residuals(x))
 
 


### PR DESCRIPTION
I think this might be something we should suggest Makie upstream handles in the definition of `QQNorm`, but the fix here won't break even if that lands upstream. `QQPlot` doesn't standardize, so users can do things on the original scale if desired (and `QQPlot` can also be used with other distributions, where standardization of this form might not make sense).