### PR TITLE
Shrinkage and Caterpillar plots for GLMM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModelsMakie"
 uuid = "b12ae82c-6730-437f-aff9-d2c38332a376"
 authors = ["Phillip Alday <me@phillipalday.com>, Douglas Bates <dmbates@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -77,8 +77,15 @@ CairoMakie.activate!(type = "svg")
 using MixedModels
 using MixedModelsMakie
 sleepstudy = MixedModels.dataset(:sleepstudy)
+verbagg = MixedModels.dataset(:verbagg)
 
 fm1 = fit(MixedModel, @formula(reaction ~ 1 + days + (1 + days|subj)), sleepstudy; progress=false)
+gm0 = fit(MixedModel,
+          @formula(r2 ~ 1 + anger + gender + btype + situ + (1|subj) + (1|item)),
+          verbagg,
+          Bernoulli();
+          progress=false)
+
 subjre = ranefinfo(fm1)[:subj]
 
 caterpillar!(Figure(; resolution=(800,600)), subjre)
@@ -90,6 +97,10 @@ caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=2)
 
 ```@example Caterpillar
 caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=nothing)
+```
+
+```@example Caterpillar
+caterpillar(gm0, :item)
 ```
 
 ```@docs
@@ -104,6 +115,9 @@ qqcaterpillar!
 qqcaterpillar(fm1)
 ```
 
+```@example Caterpillar
+qqcaterpillar(gm0, :item)
+```
 
 ```@example Caterpillar
 qqcaterpillar!(Figure(; resolution=(400,300)), subjre; cols=[1])
@@ -120,7 +134,6 @@ shrinkageplot
 shrinkageplot!
 ```
 
-
 ```@example Shrinkage
 using CairoMakie
 using MixedModels
@@ -133,6 +146,15 @@ shrinkageplot(fm1)
 
 ```@example Shrinkage
 shrinkageplot!(Figure(; resolution=(400,400)), fm1)
+```
+
+```@example Shrinkage
+gm1 = fit(MixedModel,
+          @formula(r2 ~ 1 + anger + gender + btype + situ + (1|subj) + (1+gender|item)),
+          verbagg,
+          Bernoulli();
+          progress=false)
+shrinkageplot(gm1)
 ```
 
 ## Diagnostics

--- a/src/caterpillar.jl
+++ b/src/caterpillar.jl
@@ -35,7 +35,7 @@ end
 
 Return a `RanefInfo` corresponding to the grouping variable `gf` model `m`.
 """
-function ranefinfo(m::MixedModel, gf::Symbol, re=ranef(m))
+function ranefinfo(m::LinearMixedModel, gf::Symbol, re=ranef(m))
     idx = findfirst(==(gf), fnames(m))
     isnothing(idx) &&
         throw(ArgumentError("$gf is not the name of a grouping variable in the model"))
@@ -49,6 +49,8 @@ function ranefinfo(m::MixedModel, gf::Symbol, re=ranef(m))
         Matrix(adjoint(dropdims(sqrt.(mapslices(diag, cv; dims=1:2)); dims=2))),
     )
 end
+
+ranefinfo(m::GeneralizedLinearMixedModel, args...; kwargs...) = ranefinfo(m.LMM, args...; kwargs...)
 
 """
     caterpillar!(f::Figure, r::RanefInfo; orderby=1)
@@ -93,7 +95,7 @@ Returns a `Figure` of a "caterpillar plot" of the random-effects means and predi
 A "caterpillar plot" is a horizontal error-bar plot of conditional means and standard deviations
 of the random effects.
 """
-function caterpillar(m::LinearMixedModel, gf::Symbol=first(fnames(m)))
+function caterpillar(m::MixedModel, gf::Symbol=first(fnames(m)))
     return caterpillar!(Figure(; resolution=(1000, 800)), ranefinfo(m)[gf])
 end
 
@@ -136,7 +138,7 @@ Returns a `Figure` of a "qq-caterpillar plot" of the random-effects means and pr
 
 The display can be restricted to a subset of random effects associated with a grouping variable by specifying `cols`, either by indices or term names.
 """
-function qqcaterpillar(m::LinearMixedModel, gf::Symbol=first(fnames(m)); cols=nothing)
+function qqcaterpillar(m::MixedModel, gf::Symbol=first(fnames(m)); cols=nothing)
     reinfo = ranefinfo(m, gf)
     cols = something(cols, axes(reinfo.cnames, 1))
     return qqcaterpillar!(Figure(; resolution=(1000, 800)), reinfo; cols=cols)

--- a/src/shrinkage.jl
+++ b/src/shrinkage.jl
@@ -77,8 +77,14 @@ function shrinkageplot!(
 end
 
 function _ranef(m::LinearMixedModel, θref)
-    vv = ranef(updateL!(setθ!(m, θref)))
-    updateL!(setθ!(m, m.optsum.final)) # restore parameter estimates and update m
+    vv = try
+        ranef(updateL!(setθ!(m, θref)))
+    catch e
+        @error "Failed to compute unshrunken values with the following exception:"
+        rethrow(e)
+    finally
+        updateL!(setθ!(m, m.optsum.final)) # restore parameter estimates and update m
+    end
     return vv
 end
 

--- a/src/shrinkage.jl
+++ b/src/shrinkage.jl
@@ -44,7 +44,7 @@ function splomaxes!(f::Figure, labels, panel!::Function; extraticks::Bool=false)
 end
 
 """
-    shrinkageplot!(f::Figure, m::LinearMixedModel, gf::Symbol=first(fnames(m)), θref)
+    shrinkageplot!(f::Figure, m::MixedModel, gf::Symbol=first(fnames(m)), θref)
 
 Return a scatter-plot matrix of the conditional means, b, of the random effects for grouping factor `gf`.
 
@@ -54,17 +54,16 @@ conditional means can be regarded as unpenalized.
 """
 function shrinkageplot!(
     f::Figure,
-    m::LinearMixedModel{T},
+    m::MixedModel{T},
     gf::Symbol=first(fnames(m)),
-    θref::AbstractVector{T}=10000 .* m.optsum.initial,
+    θref::AbstractVector{T}= (isa(m, LinearMixedModel) ? 1e4 : 1) .* m.optsum.initial,
 ) where {T}
     reind = findfirst(==(gf), fnames(m))  # convert the symbol gf to an index
     if isnothing(reind)
         throw(ArgumentError("gf=$gf is not one of the grouping factor names, $(fnames(m))"))
     end
-    reest = ranef(m)[reind]               # random effects conditional means at estimated θ
-    reref = ranef(updateL!(setθ!(m, θref)))[reind]  # same at θref
-    updateL!(setθ!(m, m.optsum.final))    # restore parameter estimates and update m
+    reest = ranef(m)[reind]          # random effects conditional means at estimated θ
+    reref = _ranef(m, θref)[reind]   # same at θref
     function pfunc(ax, i, j)
         x, y = view(reref, j, :), view(reref, i, :)
         scatter!(ax, x, y; color=(:red, 0.25))   # reference points
@@ -77,8 +76,29 @@ function shrinkageplot!(
     return f
 end
 
+function _ranef(m::LinearMixedModel, θref)
+    vv = ranef(updateL!(setθ!(m, θref)))
+    updateL!(setθ!(m, m.optsum.final)) # restore parameter estimates and update m
+    return vv
+end
+
+function _ranef(m::GeneralizedLinearMixedModel, θref)
+    fast = length(m.θ) == length(m.optsum.final)
+    setpar! = fast ? MixedModels.setθ! : MixedModels.setβθ!
+    vv = try
+        ranef(pirls!(setpar!(m, θref), fast, false)) # not verbose
+    catch e
+        @error "Failed to compute unshrunken values with the following exception:"
+        rethrow(e)
+    finally
+        pirls!(setpar!(m, m.optsum.final), fast, false) # restore parameter estimates and update m
+    end
+
+    return vv
+end
+
 """
-    shrinkageplot(m::LinearMixedModel, gf::Symbol=first(fnames(m)), θref)
+    shrinkageplot(m::MixedModel, gf::Symbol=first(fnames(m)), θref)
 
 Return a scatter-plot matrix of the conditional means, b, of the random effects for grouping factor `gf`.
 
@@ -86,7 +106,7 @@ Two sets of conditional means are plotted: those at the estimated parameter valu
 The default `θref` results in `Λ` being a very large multiple of the identity.  The corresponding
 conditional means can be regarded as unpenalized.
 """
-function shrinkageplot(m::LinearMixedModel{T}, args...) where {T}
+function shrinkageplot(m::MixedModel, args...)
     f = Figure(; resolution=(1000, 1000)) # use an aspect ratio of 1 for the whole figure
 
     return shrinkageplot!(f, m, args...)
@@ -107,4 +127,3 @@ function splom!(f::Figure, df::DataFrame; addcontours::Bool=false)
     end
     splomaxes!(f, names(df), pfunc)
 end
-


### PR DESCRIPTION
I've changed the "large" lambda for GLMM to be 1 because anything much larger than that created problems. I suspect that's because of the (lack of) dispersion parameter and the scaling on the locally approximating LMM. But do correct me if I'm wrong....

I've also added some error recovery code when the linear algebra fails for computing random effects.