### PR TITLE
ridgeplot: set xlims

### DIFF
--- a/src/ridge.jl
+++ b/src/ridge.jl
@@ -70,6 +70,17 @@ function Makie.plot!(ax::Axis, P::Type{<:RidgePlot}, allattrs::Makie.Attributes,
         ylims!(ax, 0, nticks + 1)
         allattrs.vline_at_zero[] && vlines!(ax, 0; color=(:black, 0.75), linestyle=:dash)
     end
+
+    # set x limits for small coeficients
+    df = DataFrame(x.β)
+    show_intercept || filter!(:coefname => !=(Symbol("(Intercept)")), df)
+    coef_extrema = extrema(df.β)
+    cr = (coef_extrema[2] - coef_extrema[1]) # coeficient range
+    if cr<20
+        cr = cr*0.1
+        xlims!(ax, coef_extrema[1]-cr, coef_extrema[2]+cr)
+    end
+
     return plot
 end
 


### PR DESCRIPTION
Hi,

`ridgeplots` are rather uninformative, if the all normalized coefficients are close to zero. 

Example:
```
const RNG = MersenneTwister(1909)

kb07 = MixedModels.dataset(:kb07)

contrasts = Dict(:spkr => EffectsCoding(),
				:prec => EffectsCoding(),
				:load => EffectsCoding(),
				:subj => Grouping(),
				:item => Grouping())

form = @formula(rt_trunc/1_000 ~ 1 + spkr * prec * load + (1 | subj) + (1 + prec | item))
m1 = fit(MixedModel, form, kb07; contrasts)
samp = parametricbootstrap(RNG, 1_000, m1);

ridgeplot(samp, show_intercept=false)
```


I suggest to set the `xlims!` in this case.

Greetings,
Oliver