### PR TITLE
Adjust compat settings and `progress` named argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,11 +17,11 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-BSplineKit = "0.14, 0.15, 0.16"
+BSplineKit = "0.15, 0.16, 0.17"
 DataFrames = "1"
 Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"
 KernelDensity = "0.6.3"
-Makie = "0.18,0.19"
+Makie = "0.20"
 MixedModels = "4.14"
 PrecompileTools = "1"
 SpecialFunctions = "1, 2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModelsMakie"
 uuid = "b12ae82c-6730-437f-aff9-d2c38332a376"
 authors = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "contributors"]
-version = "0.3.28"
+version = "0.3.29"
 
 [deps]
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,6 +7,6 @@ MixedModelsMakie = "b12ae82c-6730-437f-aff9-d2c38332a376"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CairoMakie = "0.6 - 0.10"
+CairoMakie = "0.6 - 0.11"
 DataFrames = "1"
 Documenter = "0.27"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -97,15 +97,15 @@ gm0 = fit(MixedModel,
 
 subjre = ranefinfo(fm1)[:subj]
 
-caterpillar!(Figure(; resolution=(800,600)), subjre)
+caterpillar!(Figure(; size=(800,600)), subjre)
 ```
 
 ```@example Caterpillar
-caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=2)
+caterpillar!(Figure(; size=(800,600)), subjre; orderby=2)
 ```
 
 ```@example Caterpillar
-caterpillar!(Figure(; resolution=(800,600)), subjre; orderby=nothing)
+caterpillar!(Figure(; size=(800,600)), subjre; orderby=nothing)
 ```
 
 ```@example Caterpillar
@@ -129,11 +129,11 @@ qqcaterpillar(gm0, :item)
 ```
 
 ```@example Caterpillar
-qqcaterpillar!(Figure(; resolution=(400,300)), subjre; cols=[1])
+qqcaterpillar!(Figure(; size=(400,300)), subjre; cols=[1])
 ```
 
 ```@example Caterpillar
-qqcaterpillar!(Figure(; resolution=(400,300)), subjre; cols=[:days])
+qqcaterpillar!(Figure(; size=(400,300)), subjre; cols=[:days])
 ```
 
 ### Shrinkage Plots
@@ -159,7 +159,7 @@ shrinkageplot(fm1; ellipse=true)
 ```
 
 ```@example Shrinkage
-shrinkageplot!(Figure(; resolution=(400,400)), fm1)
+shrinkageplot!(Figure(; size=(400,400)), fm1)
 ```
 
 ```@example Shrinkage
@@ -261,7 +261,7 @@ data = rmul!(randn(100, 3), LowerTriangular([+1 +0 +0;
                                              -1 -1 +1]))
 df = DataFrame(data, [:x, :y, :z])
 
-splom!(Figure(; resolution=(800, 800)), df)
+splom!(Figure(; size=(800, 800)), df)
 ```
 
 Meanwhile, `splomaxes!` provides a lower-level backend for `splom!`
@@ -286,6 +286,6 @@ function pfunc(ax, i, j)
     text!(ax, "r=$(cc)")
     return ax
 end
-splomaxes!(Figure(; resolution=(800, 800)),
+splomaxes!(Figure(; size=(800, 800)),
            names(df), pfunc)
 ```

--- a/src/caterpillar.jl
+++ b/src/caterpillar.jl
@@ -154,7 +154,7 @@ of the random effects.
 `kwargs...` are passed on to [`caterpillar!`](@ref).
 """
 function caterpillar(m::MixedModel, gf::Symbol=first(fnames(m)); kwargs...)
-    return caterpillar!(Figure(; resolution=(1000, 800)), m, gf; kwargs...)
+    return caterpillar!(Figure(; size=(1000, 800)), m, gf; kwargs...)
 end
 
 """
@@ -222,7 +222,7 @@ Returns a `Figure` of a "qq-caterpillar plot" of the random-effects means and pr
 `kwargs...` are passed on to [`qqcaterpillar!`](@ref).
 """
 function qqcaterpillar(m::MixedModel, gf::Symbol=first(fnames(m)); kwargs...)
-    return qqcaterpillar!(Figure(; resolution=(1000, 800)), m, gf; kwargs...)
+    return qqcaterpillar!(Figure(; size=(1000, 800)), m, gf; kwargs...)
 end
 
 _cols_to_idx(::Vector{String}, cols) = cols

--- a/src/coefplot.jl
+++ b/src/coefplot.jl
@@ -17,7 +17,7 @@ function coefplot(x::Union{MixedModel,MixedModelBootstrap};
                   show_intercept=true,
                   attributes...)
     # need to guarantee a min height of 150
-    fig = Figure(; resolution=(640, max(150, 75 * _npreds(x; show_intercept))))
+    fig = Figure(; size=(640, max(150, 75 * _npreds(x; show_intercept))))
     ax = Axis(fig[1, 1])
     pl = coefplot!(ax, x; conf_level, vline_at_zero, show_intercept, attributes...)
     return Makie.FigureAxisPlot(fig, ax, pl)

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -122,7 +122,7 @@ function zetatraces!(ax::Axis, pr::MixedModelProfile, i, j)
     return ax
 end
 
-function zetatraceplot(pr::MixedModelProfile; figure=(; resolution=(800,800)))
+function zetatraceplot(pr::MixedModelProfile; figure=(; size=(800,800)))
     (; fecnames) = pr
     f = Figure(; figure)
     p = length(fecnames)

--- a/src/ridge.jl
+++ b/src/ridge.jl
@@ -29,7 +29,7 @@ function ridgeplot(x::MixedModelBootstrap;
                    show_intercept=true,
                    attributes...)
     # need to guarantee a min height of 200
-    fig = Figure(; resolution=(640, max(200, 100 * _npreds(x; show_intercept))))
+    fig = Figure(; size=(640, max(200, 100 * _npreds(x; show_intercept))))
     ax = Axis(fig[1, 1])
     if !ismissing(conf_level)
         pl = coefplot!(ax, x; conf_level, vline_at_zero, show_intercept, attributes...)

--- a/src/ridge.jl
+++ b/src/ridge.jl
@@ -32,7 +32,8 @@ function ridgeplot(x::MixedModelBootstrap;
     fig = Figure(; size=(640, max(200, 100 * _npreds(x; show_intercept))))
     ax = Axis(fig[1, 1])
     if !ismissing(conf_level)
-        pl = coefplot!(ax, x; conf_level, vline_at_zero, show_intercept, color=:black, attributes...)
+        pl = coefplot!(ax, x; conf_level, vline_at_zero, show_intercept, color=:black,
+                       attributes...)
     end
     pl = ridgeplot!(ax, x; vline_at_zero, conf_level, show_intercept, attributes...)
     return Makie.FigureAxisPlot(fig, ax, pl)

--- a/src/ridge.jl
+++ b/src/ridge.jl
@@ -32,7 +32,7 @@ function ridgeplot(x::MixedModelBootstrap;
     fig = Figure(; size=(640, max(200, 100 * _npreds(x; show_intercept))))
     ax = Axis(fig[1, 1])
     if !ismissing(conf_level)
-        pl = coefplot!(ax, x; conf_level, vline_at_zero, show_intercept, attributes...)
+        pl = coefplot!(ax, x; conf_level, vline_at_zero, show_intercept, color=:black, attributes...)
     end
     pl = ridgeplot!(ax, x; vline_at_zero, conf_level, show_intercept, attributes...)
     return Makie.FigureAxisPlot(fig, ax, pl)

--- a/src/ridge2d.jl
+++ b/src/ridge2d.jl
@@ -34,7 +34,7 @@ end
 
 """$(@doc ridge2d!)"""
 function ridge2d(bs::MixedModelBootstrap, args...; kwargs...)
-    f = Figure(; resolution=(1000, 1000)) # use an aspect ratio of 1 for the whole figure
+    f = Figure(; size=(1000, 1000)) # use an aspect ratio of 1 for the whole figure
 
     return ridge2d!(f, bs, args...; kwargs...)
 end

--- a/src/shrinkage.jl
+++ b/src/shrinkage.jl
@@ -145,7 +145,7 @@ conditional means can be regarded as unpenalized.
 `args...` and `kwargs...` are passed on to [`shrinkageplot!`](@ref)
 """
 function shrinkageplot(m::MixedModel, args...; kwargs...)
-    f = Figure(; resolution=(1000, 1000)) # use an aspect ratio of 1 for the whole figure
+    f = Figure(; size=(1000, 1000)) # use an aspect ratio of 1 for the whole figure
 
     return shrinkageplot!(f, m, args...; kwargs...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,7 +74,7 @@ g1 = fit(MixedModel,
     f = qqcaterpillar(g1)
     save(joinpath(OUTDIR, "qqcat_verbagg.png"), f)
 
-    let f = Figure(; resolution=(1000, 600))
+    let f = Figure(; size=(1000, 600))
         gl = f[1, 1] = GridLayout()
         re = ranefinfo(m2)
         qqcaterpillar!(gl, re[:item])

--- a/test/utils_and_types.jl
+++ b/test/utils_and_types.jl
@@ -25,7 +25,7 @@ m1 = fit(MixedModel,
 
 @testset "confint_table" begin
     wald = confint_table(m1, 0.68)
-    bsamp = parametricbootstrap(MersenneTwister(42), 1000, m1; hide_progress=!progress)
+    bsamp = parametricbootstrap(MersenneTwister(42), 1000, m1; progress)
     boot = confint_table(bsamp, 0.68)
 
     @test wald.coefname == boot.coefname


### PR DESCRIPTION
- Replace `resolution` named argument with `size` in Makie calls.  Restrict version of `Makie` to later versions with the `size` named argument.
- Bump allowed versions of `BSplineKit`
- Use `progress` named argument in call to `parametricbootstrap`.

We may want to wait for a new release of `CairoMakie` before incorporating these changes.  There are warnings in the tests that trace back to `CairoMakie`.