### PR TITLE
zizmor audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,9 +3,13 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+permissions: {}
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,12 +4,16 @@ on:
     types:
       - created
   workflow_dispatch:
+permissions: {}
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,28 +17,33 @@ on:
       - 'LICENSE.md'
       - 'README.md'
       - 'examples/**'
+permissions: {}
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         version: [min, 1]
         os: [ubuntu-22.04, macos-14]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Julia Setup
-        uses: julia-actions/setup-julia@v3
+        uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3
         with:
           version: ${{ matrix.version }}
       - name: Cache
-        uses: julia-actions/cache@v3
+        uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
           cache-compiled: "true"
       - name: Build
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1
       - name: Test
-        uses: julia-actions/julia-runtest@v1
+        uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Percy Upload
@@ -49,8 +54,8 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Coverage Process
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1
       - name: Coverage Upload
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -4,14 +4,18 @@ name: Doc Preview Cleanup
 on:
   pull_request:
     types: [closed]
+permissions: {}
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: gh-pages
+          persist-credentials: false
       - name: Delete preview and history + push changes
         run: |
             if [ -d "previews/PR$PRNUM" ]; then

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -18,20 +18,26 @@ on:
       - 'LICENSE.md'
       - 'README.md'
       - 'examples/**'
+permissions: {}
 jobs:
   Documenter:
     name: Documentation
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3
         with:
           version: 1
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
           cache-compiled: "true"
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      - uses: julia-actions/julia-docdeploy@e62cc8fd639797a0c2922a437d5b1b81c4a12787 # v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,21 +3,27 @@
 name: Spell Check
 on: [pull_request]
 
+permissions: {}
 jobs:
   typos-check:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@3bcd3b343e2ffaa3d23f8cfe7f78d0f8c2d0d0c6 # v1.46.0
         # don't fail on typos in files not impacted by this PR
         continue-on-error: true
         with:
             config: _typos.toml
             write_changes: true
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         with:
           tool_name: Typos
           fail_on_error: true

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check spelling
-        uses: crate-ci/typos@3bcd3b343e2ffaa3d23f8cfe7f78d0f8c2d0d0c6 # v1.46.0
+        uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
         # don't fail on typos in files not impacted by this PR
         continue-on-error: true
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -5,16 +5,22 @@ on:
     paths-ignore:
       - 'README.md'
       - '.gitignore'
+permissions: {}
 jobs:
   format-check:
     name: Style Enforcement
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         julia-version: [min]
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: ${{ matrix.julia-version }}
       - name: Install JuliaFormatter
@@ -28,7 +34,7 @@ jobs:
           using JuliaFormatter
           format(".", YASStyle(); verbose=true) || exit(1)
       # Add formatting suggestions to non-draft PRs even if "Check formatting" fails
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         if: ${{ !cancelled() && github.event.pull_request.draft == false }}
         with:
           tool_name: JuliaFormatter

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| CompatHelper.yml | CompatHelper | none (default: all) | `contents: write`, `pull-requests: write` | CompatHelper creates PRs and pushes compat bumps |
| TagBot.yml | TagBot | none (default: all) | `contents: write`, `issues: read` | TagBot creates git tags; triggered by `issue_comment` |
| ci.yml | ci | none (default: all) | `contents: read` | Read-only: checkout, test, coverage upload via token |
| docs-cleanup.yml | doc-preview-cleanup | none (default: all) | `contents: write` | Force-pushes deleted previews to gh-pages |
| documenter.yml | Documenter | none (default: all) | `contents: write`, `statuses: write` | Deploys docs to gh-pages; Documenter.jl posts commit statuses |
| spellcheck.yml | typos-check | none (default: all) | `contents: read`, `pull-requests: write` | reviewdog/action-suggester posts inline PR suggestions |
| style.yml | format-check | none (default: all) | `contents: read`, `pull-requests: write` | reviewdog/action-suggester posts inline PR suggestions |
| zizmor.yaml | zizmor | — (new file) | `contents: read` | Read-only: clone repo for security scan |
